### PR TITLE
`token` should no longer be a required property

### DIFF
--- a/lib/metadata/fetchMetadata.js
+++ b/lib/metadata/fetchMetadata.js
@@ -27,7 +27,7 @@ exports.fetchMetadata = function fetchMetadata(next) {
 			Arrow.Metadata.Text({
 				name: 'token',
 				description: 'token for login',
-				required: true,
+				required: false,
 				validator: /[a-z\d]{15,}/i
 			})
 		]


### PR DESCRIPTION
With the completion of https://jira.appcelerator.org/browse/DEVOPS-2697, the `token` config property should no longer be required since the user can now access salesforce without the token as long as they white list the static IP address of the Appcelerator Public cloud for their salesforce account. For more information on setting the trusted IP range with Salesforce.com, see their documentation here:

https://help.salesforce.com/apex/HTViewHelpDoc?id=security_networkaccess.htm
